### PR TITLE
fix transform scale issue v2

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -640,8 +640,8 @@ export default function sortableContainer(
       for (let i = 0, len = nodes.length; i < len; i++) {
         const {node} = nodes[i];
         const {index} = node.sortableInfo;
-        const width = node.offsetWidth;
-        const height = node.offsetHeight;
+        const width = node.getBoundingClientRect().width;
+        const height = node.getBoundingClientRect().height;
         const offset = {
           height: this.height > height ? height / 2 : this.height / 2,
           width: this.width > width ? width / 2 : this.width / 2,


### PR DESCRIPTION
wrong node width and heigh (don't get the real size of the node based on zoom, transform etc.) in animateNodes method